### PR TITLE
Use /usr/bin/env for Python shebang.

### DIFF
--- a/fetch-inputs.py
+++ b/fetch-inputs.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python2.7
 
 import sys, os, subprocess, shutil
 

--- a/package-rust.py
+++ b/package-rust.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python2.7
 
 import sys, os, subprocess, shutil
 


### PR DESCRIPTION
I've switched the #! lines to use `env` so that the correct Python version is selected on all Unix-y platforms. With the previous `/usr/bin/python` my system tried to run the script with Python 3.