### PR TITLE
Support std packages

### DIFF
--- a/exe/rust-old.iss
+++ b/exe/rust-old.iss
@@ -45,7 +45,6 @@ Name: gcc; Description: "Linker and platform libraries"; Types: full
 #endif
 Name: docs; Description: "HTML documentation"; Types: full
 Name: cargo; Description: "Cargo, the Rust package manager"; Types: full
-Name: std; Description: "The Rust Standard Library"; Types: full
 
 [Files]
 Source: "rustc/*.*"; DestDir: "{app}"; Flags: ignoreversion recursesubdirs; Components: rust
@@ -54,7 +53,6 @@ Source: "rust-mingw/*.*"; DestDir: "{app}"; Flags: ignoreversion recursesubdirs;
 #endif
 Source: "rust-docs/*.*"; DestDir: "{app}"; Flags: ignoreversion recursesubdirs; Components: docs
 Source: "cargo/*.*"; DestDir: "{app}"; Flags: ignoreversion recursesubdirs; Components: cargo
-Source: "rust-std/*.*"; DestDir: "{app}"; Flags: ignoreversion recursesubdirs; Components: std
 
 [Code]
 const

--- a/msi/Makefile
+++ b/msi/Makefile
@@ -14,6 +14,7 @@ RUSTCDIR ?= rustc
 GCCDIR ?= rust-mingw
 DOCSDIR ?= rust-docs
 CARGODIR ?= cargo
+STDDIR ?= rust-std
 
 OBJS=$(SRCS:.wxs=.wixobj)
 # %WIX% variable contains path to WIX installdir (with trailing backslash) and is set by WiX installer
@@ -26,7 +27,7 @@ LIGHT="$(WIX)bin\light.exe"
 RM ?= del
 
 HEAT_FLAGS= -nologo -gg -sfrag -srd -sreg
-CANDLE_FLAGS= -nologo -dRustcDir=$(RUSTCDIR) -dDocsDir=$(DOCSDIR) -dCargoDir=$(CARGODIR) -arch $(CFG_PLATFORM)
+CANDLE_FLAGS= -nologo -dRustcDir=$(RUSTCDIR) -dDocsDir=$(DOCSDIR) -dCargoDir=$(CARGODIR) -dStdDir=$(STDDIR) -arch $(CFG_PLATFORM)
 ifeq ($(CFG_MINGW),1)
 CANDLE_FLAGS += -dGccDir=$(GCCDIR)
 endif
@@ -59,7 +60,7 @@ CargoGroup.wxs:
 	$(HEAT) dir $(CARGODIR) $(HEAT_FLAGS) -cg CargoGroup -dr Cargo -var var.CargoDir -out $@ -t remove-duplicates.xsl
 
 StdGroup.wxs:
-	$(HEAT) dir $(RUSTCDIR) $(HEAT_FLAGS) -cg StdGroup -dr Std -var var.StdDir -out $@
+	$(HEAT) dir $(STDDIR) $(HEAT_FLAGS) -cg StdGroup -dr Std -var var.StdDir -out $@
 
 clean:
 	$(RM) $(MSI).msi $(OBJS) $(FILEGROUPS)

--- a/msi/Makefile-old
+++ b/msi/Makefile-old
@@ -4,11 +4,11 @@ else
   MSI = rust
 endif
 
-FILEGROUPS=RustcGroup.wxs DocsGroup.wxs CargoGroup.wxs StdGroup.wxs
+FILEGROUPS=RustcGroup.wxs DocsGroup.wxs CargoGroup.wxs
 ifeq ($(CFG_MINGW),1)
 FILEGROUPS += GccGroup.wxs
 endif
-SRCS=rust.wxs ui.wxs rustwelcomedlg.wxs $(FILEGROUPS)
+SRCS=rust-old.wxs ui.wxs rustwelcomedlg.wxs $(FILEGROUPS)
 
 RUSTCDIR ?= rustc
 GCCDIR ?= rust-mingw
@@ -57,9 +57,6 @@ DocsGroup.wxs:
 
 CargoGroup.wxs:
 	$(HEAT) dir $(CARGODIR) $(HEAT_FLAGS) -cg CargoGroup -dr Cargo -var var.CargoDir -out $@ -t remove-duplicates.xsl
-
-StdGroup.wxs:
-	$(HEAT) dir $(RUSTCDIR) $(HEAT_FLAGS) -cg StdGroup -dr Std -var var.StdDir -out $@
 
 clean:
 	$(RM) $(MSI).msi $(OBJS) $(FILEGROUPS)

--- a/msi/rust-old.wxs
+++ b/msi/rust-old.wxs
@@ -136,7 +136,6 @@
                     <?endif?>
                     <Directory Id="Docs" Name="." />
                     <Directory Id="Cargo" Name="." />
-                    <Directory Id="Std" Name="." />
                 </Directory>
             </Directory>
 
@@ -201,16 +200,9 @@
                  <ComponentRef Id="RustShellShortcut" />
                  <ComponentRef Id="InstallDir" />
         </Feature>
-        <Feature Id="Std"
-                 Title="The Rust Standard Library"
-                 Display="2"
-                 Level="1"
-                 AllowAdvertise="no">
-                 <ComponentGroupRef Id="StdGroup" />
-        </Feature>
         <Feature Id="Cargo"
                  Title="Cargo, the Rust package manager"
-                 Display="3"
+                 Display="2"
                  Level="1"
                  AllowAdvertise="no">
                  <ComponentGroupRef Id="CargoGroup" />
@@ -219,7 +211,7 @@
             <Feature Id="Gcc"
                      Title="Linker and platform libraries"
                      Description="If you choose to not install this component, you will require an external MinGW installation in order to create executables and libraries."
-                     Display="4"
+                     Display="3"
                      Level="1"
                      AllowAdvertise="no">
                      <ComponentGroupRef Id="GccGroup" />
@@ -227,7 +219,7 @@
         <?endif?>
         <Feature Id="Docs"
                  Title="HTML documentation"
-                 Display="5"
+                 Display="4"
                  Level="1"
                  AllowAdvertise="no">
                  <ComponentGroupRef Id="DocsGroup" />
@@ -236,7 +228,7 @@
         <Feature Id="Path"
                  Title="Add to PATH"
                  Description="Add Rust to PATH environment variable"
-                 Display="6"
+                 Display="5"
                  Level="5"
                  AllowAdvertise="no">
                  <ComponentRef Id="PathEnvPerMachine" />

--- a/msi/rust.wxs
+++ b/msi/rust.wxs
@@ -202,7 +202,7 @@
                  <ComponentRef Id="InstallDir" />
         </Feature>
         <Feature Id="Std"
-                 Title="The Rust Standard Library"
+                 Title="The Rust standard library"
                  Display="2"
                  Level="1"
                  AllowAdvertise="no">

--- a/package-rust.py
+++ b/package-rust.py
@@ -391,6 +391,7 @@ if make_exe or make_msi:
     if make_exe:
         # Copy installer files, etc.
         shutil.copyfile("./exe/rust.iss", exe_temp_dir + "/rust.iss")
+        shutil.copyfile("./exe/rust-old.iss", exe_temp_dir + "/rust-old.iss")
         shutil.copyfile("./exe/modpath.iss", exe_temp_dir + "/modpath.iss")
         shutil.copyfile("./exe/upgrade.iss", exe_temp_dir + "/upgrade.iss")
         shutil.copyfile("./gfx/rust-logo.ico", exe_temp_dir + "/rust-logo.ico")
@@ -423,7 +424,7 @@ if make_exe or make_msi:
         if std_installer:
             run(["make", "SVAL=%i" % msi_sval])
         else:
-            run(["make", "SVAL=%i" % msi_sval, "Makefile-old"])
+            run(["make", "SVAL=%i" % msi_sval, "-f", "Makefile-old"])
         os.chdir(cwd)
 
         msifile = CFG_PACKAGE_NAME + "-" + CFG_BUILD + ".msi"

--- a/package-rust.py
+++ b/package-rust.py
@@ -267,7 +267,7 @@ if make_pkg:
     docs_package_name = docs_installer.replace(".tar.gz", "")
     cargo_package_name = cargo_installer.replace(".tar.gz", "")
     if std_installer:
-        std_package_name = std_installer.replace(".tar.gz", "") + "-" + target
+        std_package_name = std_installer.replace(".tar.gz", "")
     else:
         std_package_name = None
 

--- a/package-rust.py
+++ b/package-rust.py
@@ -267,7 +267,7 @@ if make_pkg:
     docs_package_name = docs_installer.replace(".tar.gz", "")
     cargo_package_name = cargo_installer.replace(".tar.gz", "")
     if std_installer:
-        std_package_name = std_installer.replace(".tar.gz", "")
+        std_package_name = std_installer.replace(".tar.gz", "") + "-" + target
     else:
         std_package_name = None
 
@@ -353,7 +353,7 @@ if make_exe or make_msi:
     orig_docs_dir = exe_temp_dir + "/" + docs_installer.replace(".tar.gz", "") + "/rust-docs"
     orig_cargo_dir = exe_temp_dir + "/" + cargo_installer.replace(".tar.gz", "") + "/cargo"
     if std_installer:
-        orig_std_dir = exe_temp_dir + "/" + std_installer.replace(".tar.gz", "") + "/rust-std"
+        orig_std_dir = exe_temp_dir + "/" + std_installer.replace(".tar.gz", "") + "/rust-std-" + target
     else:
         orig_std_dir = None
 
@@ -423,7 +423,7 @@ if make_exe or make_msi:
         if std_installer:
             run(["make", "SVAL=%i" % msi_sval])
         else:
-            run(["make", "SVAL=%i" % msi_val, "Makefile-old"])
+            run(["make", "SVAL=%i" % msi_sval, "Makefile-old"])
         os.chdir(cwd)
 
         msifile = CFG_PACKAGE_NAME + "-" + CFG_BUILD + ".msi"

--- a/pkg/Distribution-old.xml
+++ b/pkg/Distribution-old.xml
@@ -48,12 +48,6 @@
 	    >
         <pkg-ref id="org.rust-lang.cargo"/>
     </choice>
-    <choice id="rust-std" visible="true"
-	    title="Standard Library" description="The Rust Standard Library."
-	    selected="(!choices.uninstall.selected &amp;&amp; choices['rust-std'].selected) || (choices.uninstall.selected &amp;&amp; choices.install.selected)"
-	    >
-        <pkg-ref id="org.rust-lang.rust-docs"/>
-    </choice>
     <choice id="rust-docs" visible="true"
 	    title="Documentation" description="HTML documentation."
 	    selected="(!choices.uninstall.selected &amp;&amp; choices['rust-docs'].selected) || (choices.uninstall.selected &amp;&amp; choices.install.selected)"
@@ -63,7 +57,6 @@
     <pkg-ref id="org.rust-lang.rustc" version="0" onConclusion="none">rustc.pkg</pkg-ref>
     <pkg-ref id="org.rust-lang.cargo" version="0" onConclusion="none">cargo.pkg</pkg-ref>
     <pkg-ref id="org.rust-lang.rust-docs" version="0" onConclusion="none">rust-docs.pkg</pkg-ref>
-    <pkg-ref id="org.rust-lang.rust-std" version="0" onConclusion="none">rust-std.pkg</pkg-ref>
     <pkg-ref id="org.rust-lang.uninstall" version="0" onConclusion="none">uninstall.pkg</pkg-ref>
     <background file="rust-logo.png" mime-type="image/png"
                 alignment="bottomleft"/>

--- a/pkg/Distribution.xml
+++ b/pkg/Distribution.xml
@@ -13,6 +13,7 @@
     <choices-outline>
       <line choice="install">
 	<line choice="rustc"/>
+    <line choice="rust-std"/>
 	<line choice="cargo"/>
 	<line choice="rust-docs"/>
       </line>
@@ -49,10 +50,10 @@
         <pkg-ref id="org.rust-lang.cargo"/>
     </choice>
     <choice id="rust-std" visible="true"
-	    title="Standard Library" description="The Rust Standard Library."
+	    title="Standard Library" description="The Rust standard library."
 	    selected="(!choices.uninstall.selected &amp;&amp; choices['rust-std'].selected) || (choices.uninstall.selected &amp;&amp; choices.install.selected)"
 	    >
-        <pkg-ref id="org.rust-lang.rust-docs"/>
+        <pkg-ref id="org.rust-lang.rust-std"/>
     </choice>
     <choice id="rust-docs" visible="true"
 	    title="Documentation" description="HTML documentation."


### PR DESCRIPTION
Soon we're going to split std out of the rustc packages. These changes modify rust-packaging to support the new std package while also supporting the existing no-std-package world for beta/stable.

r? @alexcrichton 