### PR TITLE
Fix default install directory for MSI per-user installs

### DIFF
--- a/msi/rust.wxs
+++ b/msi/rust.wxs
@@ -106,7 +106,7 @@
 
         <!-- Set default values if RegSearch found nothing, or if we not upgrading -->
         <SetProperty Sequence="both" Before="SetINSTALLDIR1"
-            Id="INSTALLDIR_USER" Value="[LocalAppDataFolder]Apps\[ApplicationFolderName]">NOT INSTALLDIR_USER</SetProperty>
+            Id="INSTALLDIR_USER" Value="[LocalAppDataFolder]Programs\[ApplicationFolderName]">NOT INSTALLDIR_USER</SetProperty>
         <SetProperty Sequence="both" Before="SetINSTALLDIR1"
             Id="INSTALLDIR_MACHINE" Value="[$(var.PlatformProgramFilesFolder)][ApplicationFolderName]">NOT INSTALLDIR_MACHINE</SetProperty>
 


### PR DESCRIPTION
The correct directory is %LocalAppData%\Programs from:
https://msdn.microsoft.com/en-us/library/windows/desktop/dd408068.aspx

There is probably a more correct way of doing this because the installer
is supposed to automatically redirect from ProgramFilesFolder for per-user
installs.