### PR TITLE
Make a few improvements to the MSIs

### DIFF
--- a/msi/Makefile
+++ b/msi/Makefile
@@ -31,7 +31,7 @@ CANDLE_FLAGS= -nologo -dRustcDir=$(RUSTCDIR) -dDocsDir=$(DOCSDIR) -dCargoDir=$(C
 ifeq ($(CFG_MINGW),1)
 CANDLE_FLAGS += -dGccDir=$(GCCDIR)
 endif
-LIGHT_FLAGS= -nologo -ext WixUIExtension
+LIGHT_FLAGS= -nologo -ext WixUIExtension -ext WixUtilExtension
 ifeq ($(SVAL),1)
 	LIGHT_FLAGS += -sval
 endif

--- a/msi/rust.wxs
+++ b/msi/rust.wxs
@@ -127,6 +127,11 @@
         <SetProperty Sequence="execute" Before="CostFinalize"
             Id="ARPINSTALLLOCATION" Value="[INSTALLDIR]" />
 
+        <!-- Path of cmd.exe for the shortcut -->
+        <Property Id="SHORTCUTTARGET" Value="%windir%\System32\cmd.exe" />
+        <!-- Microsoft Installer will resolve any Enviroment Variables in the working directory at install time -->
+        <Property Id="SHORTCUTWKDIR" Value="%SystemDrive%\" />
+
         <InstallUISequence>
             <FindRelatedProducts After="AppSearch" />
         </InstallUISequence>
@@ -192,9 +197,9 @@
                         <Shortcut Id="RustShell"
                                   Name="$(var.ProductName) Shell"
                                   Description="Opens Command Prompt with Rust tools directory added to the PATH"
-                                  Target="[SystemFolder]CMD.exe"
+                                  Target="[SHORTCUTTARGET]"
                                   Arguments="/K path [INSTALLDIR]bin;%PATH%"
-                                  WorkingDirectory="PersonalFolder">
+                                  WorkingDirectory="SHORTCUTWKDIR">
                             <Icon Id="rust2.ico" SourceFile="rust-logo.ico" />
                         </Shortcut>
                         <RegistryValue Root="HKMU" Key="$(var.BaseRegKey)" Name="RustShell" Type="integer" Value="1" KeyPath="yes" />
@@ -210,8 +215,6 @@
                     </Component>
                 </Directory>
             </Directory>
-
-            <Directory Id="PersonalFolder" />
 
         </Directory>
 

--- a/msi/rust.wxs
+++ b/msi/rust.wxs
@@ -154,6 +154,10 @@
         <!-- Specifies a single cab file to be embedded in the installer's .msi. -->
         <MediaTemplate EmbedCab="yes" CompressionLevel="high" />
 
+        <!-- Send a WM_SETTINGCHANGE message to tell processes like explorer to update their
+             environments so any new command prompts get the updated %PATH% -->
+        <CustomActionRef Id="WixBroadcastEnvironmentChange" />
+
         <!-- Installation directory and files are defined in Files.wxs -->
         <Directory Id="TARGETDIR" Name="SourceDir">
             <Directory Id="$(var.PlatformProgramFilesFolder)">

--- a/msi/rust.wxs
+++ b/msi/rust.wxs
@@ -83,7 +83,7 @@
         <Property Id="ApplicationFolderName" Value="Rust $(env.CFG_CHANNEL) $(env.CFG_ABI) $(env.CFG_VER_MAJOR).$(env.CFG_VER_MINOR)" />
         <Property Id="WixAppFolder" Value="WixPerMachineFolder" />
         <Property Id="ARPPRODUCTICON" Value="rust.ico" />
-        <Property Id="ARPURLINFOABOUT" Value="http://www.rust-lang.org/" />
+        <Property Id="ARPURLINFOABOUT" Value="https://www.rust-lang.org/" />
         <Property Id="ARPCOMMENTS" Value="$(env.CFG_RELEASE_INFO)" />
         <!-- This is a dual-mode package. http://msdn.microsoft.com/en-us/library/windows/desktop/dd408068.aspx -->
         <Property Id="ALLUSERS" Value="2" Secure="yes" />


### PR DESCRIPTION
- Use https for the www.rust-lang.org link.
- Fix the cmd.exe shortcut's working directory to not point to the documents folder of whoever installed it, which is wrong if it's installed globally.
- Use the 64-bit cmd.exe on 64-bit windows for the shortcuts.
- Send a WM_SETTINGCHANGE message at the end of the MSI install to update the `%PATH%` immediately. This should help with issues like rust-lang/rust#25781 and rust-lang/rust#32419.

Note: the WM_SETTINGCHANGE change uses [WixBroadcastEnvironmentChange](http://wixtoolset.org/documentation/manual/v3/customactions/wixsettingchange.html) which requires WiX 3.10 and I believe the buildbots are still running 3.9 so they will have to be updated.