### PR TITLE
first crack at making a deb package

### DIFF
--- a/deb/postinstall
+++ b/deb/postinstall
@@ -1,0 +1,15 @@
+#!/bin/sh
+
+# symbolic link for cargo
+ln -s /usr/local/lib/cargo-nightly-x86_64-unknown-linux-gnu/cargo/bin/cargo /usr/local/bin/cargo
+
+# symbolic link for rustc
+ln -s /usr/local/lib/rustc-nightly-x86_64-unknown-linux-gnu/rustc/bin/rustc /usr/local/bin/rustc
+
+# symbolic link for rustdocs
+ln -s /usr/local/lib/rustc-nightly-x86_64-unknown-linux-gnu/rustc/bin/rustdoc /usr/local/bin/rustdoc
+
+# symbolic link for rust-gdb
+ln -s /usr/local/lib/rustc-nightly-x86_64-unknown-linux-gnu/rustc/bin/rust-gdb /usr/local/bin/rust-gdb
+
+mv /usr/local/lib/rust-std-nightly-x86_64-unknown-linux-gnu/rust-std-x86_64-unknown-linux-gnu/lib/rustlib/x86_64-unknown-linux-gnu/ /usr/local/lib/rustc-nightly-x86_64-unknown-linux-gnu/rustc/lib/rustlib/

--- a/package-rust.py
+++ b/package-rust.py
@@ -17,6 +17,7 @@ make_comb = True
 make_exe = False
 make_pkg = False
 make_msi = False
+make_deb = False
 msi_sval = False # skip msi validation
 target = None
 
@@ -31,6 +32,8 @@ for arg in sys.argv:
         make_msi = True
     elif arg == "--msi-sval":
         msi_sval = True
+    elif arg == "--deb":
+        make_deb = True
     elif "--target" in arg:
         target = arg.split("=")[1]
 
@@ -40,6 +43,7 @@ print "combined: " + str(make_comb)
 print "exe: " + str(make_exe)
 print "pkg: " + str(make_pkg)
 print "msi: " + str(make_msi)
+print "deb: " + str(make_pkg)
 print
 
 if target is None:
@@ -432,3 +436,8 @@ if make_exe or make_msi:
 
         msifile = CFG_PACKAGE_NAME + "-" + CFG_BUILD + ".msi"
         move_file(exe_temp_dir + "/" + msifile, OUTPUT_DIR + "/" + msifile)
+
+if make_deb:
+    print "creating .deb"
+
+    run(["fpm", "s", "tar", "t", "deb", "prefix", "/usr/lib", "post-install", "deb/postinstall", "in/*.tar.gz"]


### PR DESCRIPTION
Rough first pass alert. Tries to fix https://github.com/rust-lang/rust/issues/28307. I'm really not sure if this is in the right direction at all but geronimo! :)

tl;dr
I was able to get a deb package that is installing to `/usr/local/` and sets up symlinks to `/usr/local/bin` post install. cargo init and build/runs fine and rustc compiled a hello world program just fine.

git has a file size limit and it exceeds that so I have it hosted here.
http://198.74.59.46/rust-std-nightly-x86-64-unknown-linux-gnu_1.0_amd64.deb

The longer of it is that it's mostly hardcoded and I did not use the `package-rust.py` script. I did try adding a very simple function to that script but it did not work.

I ended up just using fpm to build the deb.
The command I used was 
```
fpm -s tar -t deb --prefix /usr/local/lib --post-install deb/postinstall in/cargo-nightly-x86_64-unknown-linux-gnu.tar.gz in/rustc-nightly-x86_64-unknown-linux-gnu.tar.gz in/rust-docs-nightly-x86_64-unknown-linux-gnu.tar.gz in/rust-src-nightly.tar.gz in/rust-std-nightly-x86_64-unknown-linux-gnu.tar.gz
```

I'm going to keep digging at the python script but please let me know if there is any feedback, thoughts, concerns, or if this is just completely wrong. 

Thanks in advance! :)